### PR TITLE
Add hover click switch

### DIFF
--- a/src/SessionWidget.vala
+++ b/src/SessionWidget.vala
@@ -53,6 +53,8 @@ public class A11Y.SessionWidget : Gtk.Grid {
 
         var sticky_keys = new Wingpanel.Widgets.Switch (_("Sticky Keys"));
 
+        var hover_click = new Wingpanel.Widgets.Switch (_("Hover Click"));
+
         var settings_button = new Gtk.ModelButton ();
         settings_button.text = _("Universal Access Settings…");
 
@@ -63,6 +65,7 @@ public class A11Y.SessionWidget : Gtk.Grid {
         add (slow_keys);
         add (bounce_keys);
         add (sticky_keys);
+        add (hover_click);
         add (new Wingpanel.Widgets.Separator ());
         add (settings_button);
 
@@ -99,6 +102,9 @@ public class A11Y.SessionWidget : Gtk.Grid {
         keyboard_settings.bind ("bouncekeys-enable", bounce_keys, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.bind ("slowkeys-enable", slow_keys, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.bind ("stickykeys-enable", sticky_keys, "active", SettingsBindFlags.DEFAULT);
+
+        var mouse_settings = new Settings ("org.gnome.desktop.a11y.mouse");
+        mouse_settings.bind ("dwell-click-enabled", hover_click, "active", SettingsBindFlags.DEFAULT);
     }
 
     private void update_zoom_buttons () {


### PR DESCRIPTION
Adds a switch where we can enable hover (dwell) click.

We have to use the `org.gnome.desktop` schema here and not our own because it's hardcoded into Mutter.

We'll probably also want to add some extra settings in this indicator to determine if hover clicking does primary, secondary, double click, or drag. But let's just get started with this for now.

This technically works, but is waiting on some code in Gala to show the countdown around the mouse. 