### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,15 @@ libdir = join_paths(prefix, get_option('libdir'))
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
 add_project_arguments('-DG_LOG_DOMAIN="io.elementary.wingpanel.a11y"', language:'c')
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name() + '-indicator')
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 subdir('data')
 subdir('po')
 subdir('src')

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -24,6 +24,9 @@ public class A11Y.Indicator : Wingpanel.Indicator {
     public Wingpanel.IndicatorManager.ServerType server_type { get; construct set; }
 
     public Indicator (Wingpanel.IndicatorManager.ServerType indicator_server_type) {
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+
         Object (code_name: Wingpanel.Indicator.ACCESSIBILITY,
                 server_type: indicator_server_type);
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ dependencies = [
 shared_module(
     meson.project_name(),
     files,
+    config_file,
     dependencies: dependencies,
     install: true,
     install_dir : wingpanel_indicatorsdir


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)